### PR TITLE
Added support for lines that are in the format 'id/name' for .ydk file support

### DIFF
--- a/js/main_script.js
+++ b/js/main_script.js
@@ -141,6 +141,9 @@ function generateProxies(){
 			continue;
 		}
 
+		if (lines[i].trim() !== "" && !/^\d+ /.test(lines[i])) {
+			lines[i] = '1 ' + lines[i]; // Add '1 ' to the beginning of the line
+		}
 		
 		//var regex_id_nr = 
 		var regex_name = /^([1-9][0-9]*)? ?(.+?)(?: ?\[([0-9]+)\])?\s*$/;


### PR DESCRIPTION
Added support for lines that start without a number, namely to allow ydk files to be pasted directly into the generator. To do this the code adds '1 ' to the start of lines that don't have a number. The motivation behind this request is as i recently tried pasting a ydk file into the proxy generator to find that it did not process any of the lines that just contained an id e.g. '89631139'